### PR TITLE
Remove Glossary from FAQ

### DIFF
--- a/docs/frequently_asked_questions_faq.md
+++ b/docs/frequently_asked_questions_faq.md
@@ -110,22 +110,4 @@ Below are links to discussions in the discord channel about common errors instal
 
 ---
 
-## Glossary
-**Calibration**
 
-**Charuco Board**
-
-**Media pipe**
-
-
-**Reprojection Error:**"Reprojection error" is the distance (in pixels?) between the originally measured point (i.e. the 2d skeleton) and the reconstructed 3d point reprojected back onto the image plane. 
-
-The intuition is that if the 3d reconstruction and original 2d track are perfect, then reprojection error will be Zero. If it isn't, then there is some inaccurate in either:
-
--  the original 2d tracks (i.e. bad skeleton detection in one or more cameras), 
--  in the 3d reconstruction (i.e. bad camera calibration), 
-- a combination of the two
-
-
-
-[Click here to follow a conversation about reprojection error on discord](https://discord.com/channels/760487252379041812/760489602917466133/989189718203838505)


### PR DESCRIPTION
Moving Glossary from FAQ to it's own File in /docs