### PR TITLE
transcribed `alpha` and `pre-alpha` instructions

### DIFF
--- a/docs/how_to_guides/how_to_install_and_run_the_alpha_gui.md
+++ b/docs/how_to_guides/how_to_install_and_run_the_alpha_gui.md
@@ -1,0 +1,54 @@
+# How to install and run the `alpha` GUI
+
+
+!!! warning "This is a work-in-progress :D"
+
+    No promises here, skele-friends! The `alpha` is in active development and so this is likely to change very soon. If you'd like to use the `alpha`, 
+
+Most of the dev team runs the GUI through `PyCharm`, but its easier to write instructions on how to run from an anaconda prompt.
+ 
+## Pre-requisites:
+1. Install Anaconda
+    - [https://anaconda.org](https://anaconda.org)
+2. Install [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) (just use the defaults)
+3. (OPTIONAL, but highly recommended) Install Blender - [https://blender.org](https://blender.org)
+
+## Installation instructions
+
+1. Open anaconda enabled terminal
+
+2. Create a `python=3.9` environment
+```bash
+conda create -n freemocap-gui python=3.9
+```
+
+3. Activate that environment:
+```
+conda activate freemocap-gui
+```
+
+4. Clone the repository (i.e. download the code from github. It'll show up in the current working directory of your terminal session)
+```
+git clone https://github.com/freemocap/freemocap
+```
+
+5. Navigate into that newly cloned/downloaded `freemocap` folder with:
+```
+cd freemocap
+```
+
+6. Install the dependencies listed in the `requirements.txt` file:
+```
+pip install -r requirements.txt
+```
+7. Run the GUI by running the `src/gui/main/main.py` file by entering this command into the terminal:
+```bash
+python src/gui/main/main.py
+```
+
+8. Hopefully a GUI popped up! There are no docs on usage yet, so just click and see what you can figure out :joy:
+
+
+## Current limitations
+
+At the moment, the `alpha` GUI's method for connecting to the cameras is very innefficient and will experience framerate drops with more than ~3 cameras (even with a powerful PC). We're working on a fix, and should have it handled soon! In the mean time, you can still use the GUI to process videos recorded with other methods (workflow described in the next section!)

--- a/docs/how_to_guides/how_to_use_the_pre-alpha_code.md
+++ b/docs/how_to_guides/how_to_use_the_pre-alpha_code.md
@@ -1,0 +1,55 @@
+# How to use the `pre-alpha`
+
+
+!!! info "We're in the process of launching our `alpha`..."
+
+    We're switching over to the `alpha` phase of this project (`v0.1.0` and on) , which use full refactor code written with help from a professional experienced software architect. 
+
+    Until the new code stabilizes, you may have more luck using the `pre-alpha` code (e.g. `v0.0.54`). If you'd like to try and use the `alpha` GUI, you can start [with this How-To-Guide](how_to_run_the_alpha_gui.md).
+
+## Installing the `pre-alpha`
+
+!!! take-note "Note: Our `pre-alpha` is frozen"
+
+    This will install the latest & last version from the `pre-alpha` phase of this project, frozen at release tag `v0.0.54` [here](https://github.com/freemocap/freemocap/releases/tag/v0.0.54)
+
+Open an Anaconda-enabled command prompt or powershell window and enter the following commands:
+
+1) Create a Python 3.7 Anaconda environment
+```bash 
+conda create -n freemocap-env python=3.7
+``` 
+
+2) Activate that newly created environment
+```bash
+conda activate freemocap-env
+```
+3) Install freemocap (version `0.0.54`)  from PyPi using `pip`
+```bash
+pip install freemocap==0.0.54
+```
+
+!!! warning "Warning: BUG FIX - Update `mediapipe` with `pip install mediapipe --upgrade`"
+
+That should be it!
+___
+##  How to create a new `pre-alpha` recording session
+
+tl;dr- **Activate the freemocap Python environment** and run the following lines of code (either in a script or in a console)
+
+```python
+import freemocap
+freemocap.RunMe()
+```
+
+!!! blender "Be cool, use Blender"
+
+    COOL KIDS will install Blender ([blender.org](https://blender.org) and generate an awesome `.blend` file animation by setting `useBlender=True`: 
+
+```python
+import freemocap
+freemocap.RunMe(useBlender=True)
+```
+
+**For additional, more detailed instructions (including methods to re-process recorded sessions), [refer to the `OLD_README.md` document](https://github.com/freemocap/freemocap/blob/main/OLD_README.md))**
+

--- a/docs/how_to_guides/index.md
+++ b/docs/how_to_guides/index.md
@@ -1,6 +1,9 @@
 # "How to" Guides  
 
 ## Text and pictures
+
+### [How to use the `pre-alpha`](how_to_use_the_pre-alpha_code.md)
+### [How to install and run the `alpha` GUI](how_to_install_and_run_the_alpha_gui)
 ### [How to process pre-recorded synchronized videos with `alpha` GUI]( how_to_process_previously_recorded_videos.md)
 
 


### PR DESCRIPTION
This branch is poorly named; I started with the intention of adding the basic `pre-alpha` isntructions, but then realized how easy it would be to add the `alpha` installation instructions as well

So I've transcribed two sections of freemocap's `README.md` to our documentation site