### PR TITLE
Jon/add emg video

### DIFF
--- a/docs/about_us.md
+++ b/docs/about_us.md
@@ -1,4 +1,4 @@
-#About Us
+# About Us
 
 The Free Motion Capture Project (FreeMoCap) aims to provide research-grade markerless motion capture software to everyone for free.
 
@@ -17,4 +17,8 @@ A high-quality, minimal-cost motion capture system would be a transformative too
 
 ✨💀✨
 </center>
+
+
+![type:video](https://www.youtube.com/embed/WW_WpMcbzns)
+
 (copied from [https://freemocap.org](https://freemocap.org))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ theme:
   name: material
   logo: assets/fmc-logo-transparent-bkgd.png
   favicon: assets/skelly_freemocap_favicon.ico
-  features: 
+  features:
     - navigation.tabs
     - navigation.instant
     - navigation.tracking
@@ -19,12 +19,12 @@ extra_css:
 custom_dir: overrides
 
 nav:
-   - 'index.md'
-   - 'about_us.md'
-   - 'how_to_guides/index.md'  # an index of clickable links to various guides
-   - 'terminology/terminology.md'
-   - 'roadmap/roadmap.md'  # actually the roadmap
-   
+  - 'index.md'
+  - 'about_us.md'
+  - 'how_to_guides/index.md'  # an index of clickable links to various guides
+  - 'terminology/terminology.md'
+  - 'roadmap/roadmap.md'  # actually the roadmap
+
 markdown_extensions:
   - abbr
   - attr_list
@@ -53,4 +53,5 @@ extra:
     - icon: fontawesome/brands/youtube
       link: https://www.youtube.com/c/jonmatthis
 
-
+plugins:
+  - mkdocs-video

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs-material 
+mkdocs-video


### PR DESCRIPTION
add epic megagrant video to the `about us` page

NOTE - I added the `mkdocs-video` plugin to allow enbedding the video directly in the page. **you will need to re-run `pip install -r requirements.txt` for this branch to build properly with `mkdocs serve`