### PR TITLE
mkdocs admonitions + readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,54 +13,14 @@ ___
 
 # Style Guide
 
-This is a work in progress :)
+This is a work in progress :) 
 
-The goal is to create a consistent style across all parts of the docs to create what I, Trent, am calling "semantic continuity" in how we communicate to our users. Semantic continuity means that the meaning of various symbols and text formatting is consistent across our documentation.
+> `2024-02-15` We're currently in the process of switching from Material MkDocs to WriterSide for our documentation tool. To avoid confusion, we're deleting content from this README that specifically was tied to Material MkDocs, and will fill out our style guide in the future with information that is relevant to our doc style in WriterSide.
+
+The goal is to create a consistent style across all parts of the docs to create what Trent is calling "semantic continuity" in how we communicate to our users. Semantic continuity means that the meaning of various symbols and text formatting is consistent across our documentation.
 - This could be as small as making sure that there are periods at the end of every sentence, even in bullet points.
-- Or it could be as big as making sure that [Admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/), or "call-outs", are used in the same way across the docs.
+- Or it could be as big as making sure that admonitions or "call-outs", are used in the same way across the docs.
 
-## [Admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) - AKA Call-Outs
-Our docs currently employ `6` types of Admonitions. The four which we have customized which can be found in `/stylesheets/extra.css`, and the other standard styles of admonitions can be found in [here](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types).
-
-Each of the Admonitions have a unique aesthetic and serve a specific purpose:
-
-`tip-full-width`
-- Description: Blueish box with white sparkle skelly icon. This is a custom Admonition.
-- Purpose: Provide freemocap-specific tips, for example, in "How to process pre-recorded synchronized videos with `alpha` GUI", the `tip-full-width` helps folks who are trying to post-process videos they had recorded with using the `pre-alpha`.
-
-![tip-full-width](https://user-images.githubusercontent.com/62706609/202797425-e0d0ec64-7752-4aeb-a76e-a39dd671be9f.png)
-> Developer Note: `tip-full-width` should be renamed.
-
-`take-note`
-- Description: Greenish box with a dark green pencil icon. This is a custom Admonition.
-- Purpose: Provide useful notes that are relevant to the page that the viewer is on. This call-out is important for helping folks stay on the ["happy path"](https://en.wikipedia.org/wiki/Happy_path) of getting the task they came here to do, done.
-
-![take-note_admonition](https://user-images.githubusercontent.com/62706609/202797519-31d45917-568c-40f4-9978-a6f2a2205177.png)
-
-`blender`
-- Description: Creamsicle-orange box with black [Blender](https://www.google.com/search?client=firefox-b-1-d&q=blender) logo. This is a custom Admonition.
-- Purpose: Provide information connecting freemocap to Blender. This could be linking to a Blender tutorial, or linking to the Blender download page. Blender is cool!
-
-![blender_admonition](https://user-images.githubusercontent.com/62706609/202797532-8cf8f03b-14de-4725-9c5d-933a70329000.png)
-
-`finished`
-- Description: Bright-pink box with a white happy skull icon. This is a custom Admonition.
-- Purpose: The purpose of this Admonition is to congratulate users for finishing a How-To or a Tutorial, and provide them with next steps.
-
-![finished_admonition](https://user-images.githubusercontent.com/62706609/202797567-d03ec289-8e66-4577-b831-1cd4ab4f6374.png)
-
-`info`
-- Description: Bright blue box with a bright blue circle with the letter `i` cut out as the icon. This Admonition is one of the default call-outs from `Material for MkDocs`.
-- Purpose: To provide the user with tangential, but interesting information that could be useful the the task at hand. If opened, this could easily lead the user down a rabbit hole; `info` admonitions should always be presented closed & openable by the user, implementing them in the `.md` files with `???` instead of the standard `!!!` for an open admonition.
-
-![info_admonition](https://user-images.githubusercontent.com/62706609/202797755-e8bd7d78-5ddd-412a-8084-b0e5e20e9186.png)
-
-`warning`
-- Description: Bright orange box with an orange triangle with an `!` inside of it. This Admonition is one of the default call-outs from `Material for MkDocs`.
-- Purpose: We use this call-out to clearly warn users of potential pitfalls. If this were a perfect software, we probably wouldn't have these. But it's not! And that's okay :) These call-outs will save us issue-posts.
-- Styling note: the shown text for warnings should always being with `Warning:`, and be proceeded by a detailed explanation that clearly tells the user what to avoid, or make sure they do.
-
-![warning_admonition](https://user-images.githubusercontent.com/62706609/202797732-7d7e8556-5d9e-4008-907e-bce50fb272c6.png)
 
 
 

--- a/docs/Writerside/topics/getting_started/multi_camera_calibration.md
+++ b/docs/Writerside/topics/getting_started/multi_camera_calibration.md
@@ -1,8 +1,13 @@
 # Multi-Camera Calibration Guide
-!!! tip
-     [Check out this video for more information and directed guidance in the calibration process](https://youtu.be/GxKmyKdnTy0?t=1615)
 
-**Note:** This calibration process describes the use of an anipose-based calibration method. We will soon be updating our method to use a more flexible and interactive interface.
+> This calibration process describes the use of an anipose-based calibration method. We will soon be updating our method to use a more flexible and interactive interface.
+{style="note"}
+
+<procedure title="Video Guidance" collapsible="true">
+
+[Check out this video for more information and directed guidance in the calibration process](https://youtu.be/GxKmyKdnTy0?t=1615)
+
+</procedure>
 
 ## Preparing the Charuco Board
 To perform a multi-camera calibration, you'll need to print out a [Charuco board image](https://github.com/freemocap/freemocap/blob/main/freemocap/assets/charuco/charuco_board_image.png). 
@@ -23,9 +28,9 @@ For more information about how to use the board to get a high quality calibratio
 ## Processing the Calibration
 Once you have given each camera a good view of the board shared with another camera, click "Stop Recording," and it will begin the calibration process automatically. 
 
-!!! tip
-     Be sure to keep an eye on the terminal that launched the GUI for helpful output, as the log at the bottom of the  GUI screen does not capture all of the outputs yet.
-
+> Be sure to keep an eye on the terminal that launched the GUI for helpful output, as the log at the bottom of the  GUI screen does not capture all of the outputs yet. 
+> *Note: The terminal only launches in this way on Windows*.
+{style="note"}
 
 ## Recording Motion Capture Videos
 

--- a/docs/Writerside/topics/getting_started/single_camera_recording.md
+++ b/docs/Writerside/topics/getting_started/single_camera_recording.md
@@ -19,10 +19,12 @@ Launch FreeMoCap from the terminal by activating the relevant Python environment
 ## Camera Detection
 The software should locate your cameras, and once they're connected, it will show a viewpoint from the connected camera in the GUI. You can adjust the settings in the sidebar and then click "Apply Settings to Cameras" to apply them. 
 
-!!! tip-full-width "The exposure setting is your friend!"
-    The most important setting to look at right now is the exposure setting, which you should make as low as possible to decrease blur. We generally like to keep it below -6. Adjust it downwards until the image looks crisp, which will probably make it look slightly darker than you would normally expect. 
-    
-    For this simple single-camera recording, this isn't a crucial step. As long as you can see yourself in the image, you should be tracked okay, but it's good to keep in mind for the future.
+<procedure title="Tips: Exposure and Framing" collapsible="true">
+
+> Prioritize proper exposure for the best video quality. Start by lowering your exposure setting (ideally below -6) to reduce blur and create a crisp image. This may initially make the image appear slightly darker than expected. While perfect framing isn't critical for a simple single-camera setup, ensure you're visible within the frame. Keeping good framing practices in mind will be beneficial for future, more complex recording scenarios.
+{style="note"}
+
+</procedure>
 
 ## Recording
 Because you're doing a single camera recording, you don't need to do any calibration. But when you do graduate to multi-camera recordings, this is where you would get out a Charuco board and run a calibration first. We're all clear to record our motion capture for now though.


### PR DESCRIPTION
switched admonitions in single and multi cam recordings from Material MkDocs syntax to WriterSide, updated the condensed of information on the single cam admonition to be one note instead of two.

updated the readme by removing information that pertained only to Material MkDocs