### PR TITLE
Fix one broken page

### DIFF
--- a/docs/Writerside/fmd.tree
+++ b/docs/Writerside/fmd.tree
@@ -10,7 +10,7 @@
     <toc-element toc-title="Getting Started">
         <toc-element topic="getting_started_index.md"/>
         <toc-element topic="software_hardware_prerequisites.md"/>
-        <toc-element topic="installation.md"/>
+        <toc-element topic="installation.md" accepts-web-file-names-ref="installation-redirect"/>
         <toc-element topic="your_first_recording.md"/>
         <toc-element topic="single_camera_recording.md"/>
         <toc-element topic="multi_camera_calibration.md"/>

--- a/docs/Writerside/redirection-rules.xml
+++ b/docs/Writerside/redirection-rules.xml
@@ -34,4 +34,8 @@
         <description>Created after removal of "Doc Page Templates" from FreeMoCap Main Documentation</description>
         <accepts>Templates.html</accepts>
     </rule>
+    <rule id="installation-redirect">
+        <description>Redirect installation page from mkdocs to new location</description>
+        <accepts>installation.html</accepts>
+    </rule>
 </rules>


### PR DESCRIPTION
In reference to #61, this PR attempts to redirect one of the broken pages to the current topic. According to the writerside documentation this should work, but I can't figure out how to test it in writerside. 

I'm doing "Open in Browser" to be able to change the writerside preview URL, but all of the broken URLs work in the preview, so I can't tell if this change is working. We may need to push it to see if it works.