### PR TITLE
Add testing procedure page to table of contents

### DIFF
--- a/docs/Writerside/fmd.tree
+++ b/docs/Writerside/fmd.tree
@@ -37,5 +37,6 @@
         <toc-element topic="contributing_index.md"/>
         <toc-element topic="feature_request.md"/>
         <toc-element topic="bug_report.md"/>
+        <toc-element topic="testing_procedure_for_PRs.md"
     </toc-element>
 </instance-profile>


### PR DESCRIPTION
When this page was added in #58 it wasn't added to the table of contents so there was no way to navigate to it. This PR fixes that.